### PR TITLE
Support same non-iOS platforms as Moya

### DIFF
--- a/Moya-ModelMapper.podspec
+++ b/Moya-ModelMapper.podspec
@@ -24,7 +24,11 @@ Pod::Spec.new do |s|
   s.source           = { :git => "https://github.com/sunshinejr/Moya-ModelMapper.git", :tag => s.version.to_s }
   s.social_media_url = 'https://twitter.com/thesunshinejr'
 
-  s.platform     = :ios, '9.0'
+  s.ios.deployment_target = '9.0'
+  s.osx.deployment_target = '10.11'
+  s.watchos.deployment_target = '2.0'
+  s.tvos.deployment_target = '9.0'
+
   s.requires_arc = true
   s.default_subspec = "Core"
 


### PR DESCRIPTION
This will allow usage on all platforms supported by Moya, including macOS, tvOS, and watchOS.